### PR TITLE
docs(python): drop Conda distribution

### DIFF
--- a/docs/src/intro-python.md
+++ b/docs/src/intro-python.md
@@ -21,35 +21,11 @@ Playwright recommends using the official [Playwright Pytest plugin](./test-runne
 
 Get started by installing Playwright and running the example test to see it in action.
 
-<Tabs
-  groupId="package-managers"
-  defaultValue="pypi"
-  values={[
-    {label: 'PyPI', value: 'pypi'},
-    {label: 'Anaconda', value: 'anaconda'}
-  ]
-}>
-<TabItem value="pypi">
-
 Install the [Pytest plugin](https://pypi.org/project/pytest-playwright/):
 
 ```bash
 pip install pytest-playwright
 ```
-
-</TabItem>
-<TabItem value="anaconda">
-
-Install the [Pytest plugin](https://anaconda.org/Microsoft/pytest-playwright):
-
-```bash
-conda config --add channels conda-forge
-conda config --add channels microsoft
-conda install pytest-playwright
-```
-
-</TabItem>
-</Tabs>
 
 Install the required browsers:
 

--- a/docs/src/library-python.md
+++ b/docs/src/library-python.md
@@ -5,24 +5,11 @@ title: "Getting started - Library"
 
 ## Installation
 
-### Pip
-
 [<img src="https://badge.fury.io/py/playwright.svg" alt="PyPI version" width="132" height="20" />](https://pypi.python.org/pypi/playwright/)
 
 ```bash
 pip install --upgrade pip
 pip install playwright
-playwright install
-```
-
-### Conda
-
-[<img src="https://img.shields.io/conda/v/microsoft/playwright" alt="Anaconda version" width="160" height="20" />](https://anaconda.org/Microsoft/playwright)
-
-```bash
-conda config --add channels conda-forge
-conda config --add channels microsoft
-conda install playwright
 playwright install
 ```
 


### PR DESCRIPTION
Conda packages for Playwright are no longer published, so the docs shouldn't point users at an install path that no longer works.

- `library-python.md`: removed the `### Conda` install section (and the now-redundant `### Pip` heading).
- `intro-python.md`: removed the PyPI/Anaconda `<Tabs>` wrapper, leaving the plain `pip install pytest-playwright` instructions.

Historical Conda mentions in `release-notes-python.md` are left untouched since those are past release records.

Mirrors https://github.com/microsoft/playwright-python/pull/3091